### PR TITLE
unstable: detection area enlarged, one entity = one block

### DIFF
--- a/witchtrading/data/witchtrading/functions/main.mcfunction
+++ b/witchtrading/data/witchtrading/functions/main.mcfunction
@@ -39,7 +39,7 @@ execute as @a[tag=wt.sad_orchid] at @s run function witchtrading:sad_orchid/effe
 execute as @a[scores={wt.sad_orchid=1..}] at @s run function witchtrading:sad_orchid/effects
 #calling sad_orchid:placement
 execute as @e[tag=wt.R.sad_orchid,type=minecraft:area_effect_cloud] at @s run function witchtrading:sad_orchid/placement
-title @a[scores={wt.sad_orchid=1..,wt.rng=15}] subtitle ["",{"text":"please ","color":"red"},{"text":"look at","italic":true,"color":"red"},{"text":" the ","color":"red"},{"text":"placed block","italic":true,"color":"red"}]
+title @a[scores={wt.sad_orchid=1..,wt.rng=15}] subtitle ["",{"text":"please ","color":"red"},{"text":"look at","italic":true,"color":"red"},{"text":" the ","color":"red"},{"text":"placed blue_orchid","italic":true,"color":"red"}]
 title @a[scores={wt.sad_orchid=1..,wt.rng=15}] title {"text":"error","bold":true,"color":"dark_red"}
 #calling sad_orchid:sad_orchid
 execute as @e[tag=wt.sad_orchid,type=minecraft:area_effect_cloud] at @s run function witchtrading:sad_orchid/sad_orchid

--- a/witchtrading/data/witchtrading/functions/sad_orchid/effects.mcfunction
+++ b/witchtrading/data/witchtrading/functions/sad_orchid/effects.mcfunction
@@ -4,6 +4,14 @@ tag @s[nbt=!{SelectedItem:{id:"minecraft:blue_orchid",tag:{HideFlags:1,Attribute
 execute at @s[scores={wt.rng=1}] positioned ~ ~1.35 ~ run particle minecraft:dripping_water ^-0.15 ^ ^0.275 0 0 0 1 1 normal
 
 #placement of sad_orchid
-execute at @s[scores={wt.sad_orchid=1}] run summon area_effect_cloud ~ ~ ~ {Tags:["wt.R.sad_orchid"],Duration:1}
-tp @e[tag=wt.R.sad_orchid,type=minecraft:area_effect_cloud,sort=nearest,limit=1] @s[scores={wt.sad_orchid=1}]
-execute at @s[scores={wt.sad_orchid=1}] as @e[tag=wt.R.sad_orchid,type=minecraft:area_effect_cloud,sort=nearest,limit=1] at @s run tp @s ~ ~1.5 ~
+execute at @s[scores={wt.sad_orchid=1..}] run summon area_effect_cloud ~ ~ ~ {Tags:["wt.R.sad_orchid"],Duration:1}
+execute at @s[scores={wt.sad_orchid=1..}] run summon area_effect_cloud ^1 ^1 ^ {Tags:["wt.R.sad_orchid"],Duration:1}
+execute at @s[scores={wt.sad_orchid=1..}] run summon area_effect_cloud ^1 ^-1 ^ {Tags:["wt.R.sad_orchid"],Duration:1}
+execute at @s[scores={wt.sad_orchid=1..}] run summon area_effect_cloud ^-1 ^1 ^ {Tags:["wt.R.sad_orchid"],Duration:1}
+execute at @s[scores={wt.sad_orchid=1..}] run summon area_effect_cloud ^-1 ^-1 ^ {Tags:["wt.R.sad_orchid"],Duration:1}
+execute at @s[scores={wt.sad_orchid=1..}] run summon area_effect_cloud ^ ^1 ^ {Tags:["wt.R.sad_orchid"],Duration:1}
+execute at @s[scores={wt.sad_orchid=1..}] run summon area_effect_cloud ^ ^-1 ^ {Tags:["wt.R.sad_orchid"],Duration:1}
+execute at @s[scores={wt.sad_orchid=1..}] run summon area_effect_cloud ^1 ^ ^ {Tags:["wt.R.sad_orchid"],Duration:1}
+execute at @s[scores={wt.sad_orchid=1..}] run summon area_effect_cloud ^-1 ^ ^ {Tags:["wt.R.sad_orchid"],Duration:1}
+tp @e[tag=wt.R.sad_orchid,type=minecraft:area_effect_cloud,sort=nearest,limit=1] @s[scores={wt.sad_orchid=1..}]
+execute at @s[scores={wt.sad_orchid=1..}] as @e[tag=wt.R.sad_orchid,type=minecraft:area_effect_cloud,sort=nearest,limit=9] at @s run tp @s ~ ~1.5 ~

--- a/witchtrading/data/witchtrading/functions/sad_orchid/placement.mcfunction
+++ b/witchtrading/data/witchtrading/functions/sad_orchid/placement.mcfunction
@@ -1,9 +1,12 @@
+#actual detecting ray
 execute unless block ~ ~ ~ minecraft:blue_orchid run tp @s ^ ^ ^0.5
 scoreboard players add @s wt.sad_orchid 1
-execute as @s[scores={wt.sad_orchid=..14}] at @s unless block ~ ~ ~ minecraft:blue_orchid run function witchtrading:sad_orchid/placement
-execute positioned ^ ^ ^0.5 if block ~ ~ ~ minecraft:blue_orchid run summon minecraft:area_effect_cloud ~ ~ ~ {Duration:2147483637,Tags:["wt.sad_orchid","wt.SU.sad_orchid"]}
+execute as @s[scores={wt.sad_orchid=..16}] at @s unless entity @e[type=area_effect_cloud,tag=wt.sad_orchid,tag=wt.SU.sad_orchid,distance=..8] unless block ~ ~ ~ minecraft:blue_orchid run function witchtrading:sad_orchid/placement
+execute positioned ^ ^ ^0.5 if block ~ ~ ~ minecraft:blue_orchid unless entity @e[type=area_effect_cloud,tag=wt.sad_orchid,distance=..0.75] run summon minecraft:area_effect_cloud ~ ~ ~ {Duration:2147483637,Tags:["wt.sad_orchid","wt.SU.sad_orchid"]}
+#centralizing
 execute positioned ^ ^ ^0.5 if block ~ ~ ~ minecraft:blue_orchid run summon minecraft:leash_knot ~ ~300 ~ {Tags:["wt.T.sad_orchid"]}
 execute as @e[tag=wt.sad_orchid,tag=wt.SU.sad_orchid,type=minecraft:area_effect_cloud] at @s at @e[tag=wt.T.sad_orchid,type=minecraft:leash_knot,sort=nearest,limit=1] run tp @s ~ ~-300 ~
-kill @e[tag=wt.T.sad_orchid,type=minecraft:leash_knot]
-tag @e[tag=wt.sad_orchid,tag=wt.SU.sad_orchid,type=minecraft:area_effect_cloud] remove wt.SU.sad_orchid
-execute positioned ^ ^ ^0.5 if block ~ ~ ~ minecraft:blue_orchid run scoreboard players remove @p[scores={wt.sad_orchid=1..}] wt.sad_orchid 1
+#end loop
+execute positioned ^ ^ ^0.5 if block ~ ~ ~ minecraft:blue_orchid if entity @e[type=area_effect_cloud,tag=wt.sad_orchid,tag=wt.SU.sad_orchid,distance=..0.75] run scoreboard players remove @p[scores={wt.sad_orchid=1..}] wt.sad_orchid 1
+#calling sad_orchid/setup
+execute as @e[tag=wt.T.sad_orchid,type=minecraft:leash_knot] at @s run function witchtrading:sad_orchid/setup

--- a/witchtrading/data/witchtrading/functions/sad_orchid/setup.mcfunction
+++ b/witchtrading/data/witchtrading/functions/sad_orchid/setup.mcfunction
@@ -1,0 +1,3 @@
+tag @e[tag=wt.sad_orchid,tag=wt.SU.sad_orchid,type=minecraft:area_effect_cloud,sort=nearest,limit=1] remove wt.SU.sad_orchid
+tp @s ~ -500 ~
+kill @s


### PR DESCRIPTION
First attempt: very strange behaviour. Too many strange bugs. This commit is only here for later research.
I should first focus on the default mechanic working properly, instead of trying to fix the placement-API.

This branch will be happening inside of witchtrading as this mechanic is already featured there through the sad_orchid. Here, I'll try to fix the placement-API (which the sad_orchid makes use off) in a proper, non-hacky and reliable way. If this branch is done, it will be merged to master and new features will be added in other datapacks using this API.

[latest master [commit](https://github.com/Metroite/datapacks/commit/3432d6c966e4c461c1a62fb59aa4afce9ebc6c1f) made use of the work done here, it should be merged now]